### PR TITLE
:sailboat: Do not log every request as object as info

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -2,13 +2,11 @@
 const router = require('express').Router();
 const renderer = require('../app/middleware/renderer');
 const setLocals = require('../app/middleware/setLocals');
-const log = require('../app/middleware/logger');
 const searchValidator = require('../app/middleware/searchValidator');
 const getGps = require('../app/middleware/getGps');
 const logZeroResults = require('../app/middleware/logZeroResults');
 
 router.get('/results',
-  log.info,
   setLocals.fromRequest,
   searchValidator,
   getGps,
@@ -17,7 +15,6 @@ router.get('/results',
 );
 
 router.get('/',
-  log.info,
   setLocals.fromRequest,
   renderer.searchForYourGp
 );


### PR DESCRIPTION
There is already a `log.debug` running for all requests