### PR TITLE
Remove reliance on rancher-templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 after_success:
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - ./scripts/ci-deployment/docker_ci.sh
-  - ./scripts/ci-deployment/rancher_pr_deploy.sh
+  - bash ./scripts/ci-deployment/deploy.sh
 
 script:
   - docker-compose -f docker-compose-tests.yml build travis-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: node_js
 node_js:
   - node
@@ -8,10 +6,7 @@ services:
   - docker
 
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
+  - pip install docker-compose
 
 after_success:
   - bash ./scripts/ci-deployment/deploy.sh

--- a/config/config.js
+++ b/config/config.js
@@ -1,8 +1,8 @@
 const path = require('path');
 
 const rootPath = path.normalize(`${__dirname}/..`);
-const host = 'mongo';
-const port = '27017';
+const host = process.env.MONGODB_HOST || 'mongo';
+const port = process.env.MONGODB_PORT || 27017;
 const db = 'profiles';
 
 module.exports = {

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+
+  gp-finder-frontend:
+    image: "nhsuk/gp-finder:$DOCKER_IMAGE_TAG"
+    environment:
+      NODE_ENV: production
+      HOTJAR_ANALYTICS_TRACKING_ID: $HOTJAR_ID
+      GOOGLE_ANALYTICS_TRACKING_ID: $GOOGLE_ID
+      WEBTRENDS_ANALYTICS_TRACKING_ID: $WEBTRENDS_ID
+    labels:
+      traefik.enable: stack
+      traefik.domain: $TRAEFIK_DOMAIN
+      traefik.port: 3000
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.affinity:host_label_soft: c2s=true

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       traefik.enable: stack
       traefik.domain: $TRAEFIK_DOMAIN
       traefik.port: 3000
+      map-public-http: 3000
       io.rancher.container.pull_image: always
       io.rancher.scheduler.affinity:host_label_soft: c2s=true

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       HOTJAR_ANALYTICS_TRACKING_ID: $HOTJAR_ID
       GOOGLE_ANALYTICS_TRACKING_ID: $GOOGLE_ID
       WEBTRENDS_ANALYTICS_TRACKING_ID: $WEBTRENDS_ID
+      MONGODB_HOST: profiles-db.profiles-db
     labels:
       traefik.enable: stack
       traefik.domain: $TRAEFIK_DOMAIN

--- a/rancher-config/rancher-compose.yml
+++ b/rancher-config/rancher-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+
+  gp-finder-frontend:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 5000
+      healthy_threshold: 2
+      port: 3000
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 5000
+      strategy: recreate
+      request_line: GET "/" "HTTP/1.0"
+      reinitializing_timeout: 60000


### PR DESCRIPTION
Uses the latest version of the CI scripts, which includes the production docker-compose files for rancher.