### PR TITLE
Remove invalid wget parameter

### DIFF
--- a/scripts/container/utils
+++ b/scripts/container/utils
@@ -8,7 +8,7 @@ wait_for_es_to_start() {
   ES_PORT=${ES_PORT:-9200}
 
   echo "Waiting for a response from http://$ES_HOST:$ES_PORT"
-  while ! wget -s -q http://"$ES_HOST":"$ES_PORT" ; do
+  while ! wget -q http://"$ES_HOST":"$ES_PORT" ; do
     if [ $count -gt $max_count ];
     then
       break


### PR DESCRIPTION
Since the upgrade to node:8.1.4-alpine the wget command fails due to
an invalid option (-s). Presume it was just ignored previously.