### PR TITLE
Fix issue when search is not provided and postcode is valid

### DIFF
--- a/app/middleware/getGps.js
+++ b/app/middleware/getGps.js
@@ -19,13 +19,18 @@ function mapResults(results, res, searchTerm) {
     // eslint-disable-next-line no-underscore-dangle
     const gp = result._source;
 
-    // eslint-disable-next-line no-param-reassign
-    gp.bookOnlineLink = gpDataMapper.getBookOnlineLink(gp);
-    // eslint-disable-next-line no-param-reassign
-    gp.filterGps = gpDataMapper.mappedTitleForGps(gpDataMapper.getFilteredGps(gp, searchTerm));
+    if (gp) {
+      // eslint-disable-next-line no-param-reassign
+      gp.bookOnlineLink = gpDataMapper.getBookOnlineLink(gp);
 
-    if (result.sort) {
-      gp.distance = result.sort[0];
+      if (searchTerm) {
+        // eslint-disable-next-line no-param-reassign
+        gp.filterGps = gpDataMapper.mappedTitleForGps(gpDataMapper.getFilteredGps(gp, searchTerm));
+      }
+
+      if (result.sort) {
+        gp.distance = result.sort[0];
+      }
     }
 
     return gp;

--- a/test/integration/resultsForPostcode.js
+++ b/test/integration/resultsForPostcode.js
@@ -48,6 +48,21 @@ function expectErrorMessagesForPostcode(res, errorMessage, errorMessage2) {
 
 describe('Results page with postcode search', () => {
   describe('Search by valid full postcode', () => {
+    it('of \'HG5 0JL\' when search is not there should ignore search param', (done) => {
+      const search = undefined;
+      const postcode = 'HG5 0JL';
+
+      makeSearchRequestAndCheckExpectations(search, postcode, (err, res) => {
+        const $ = cheerio.load(res.text);
+        const pageTitle = $('.page-title').text();
+        const resultsHeader = $('.results__header').text();
+
+        expect(pageTitle).to.not.contain('Sorry, we are experiencing technical problems');
+        expect(resultsHeader).to.contain('Which is your surgery?');
+        done();
+      });
+    });
+
     it(`of 'HG5 0JL' should rank 'Beech House Surgery' in the first ${RESULTS_THRESHOLD} results`, (done) => {
       const search = '';
       const postcode = 'HG5 0JL';
@@ -58,6 +73,7 @@ describe('Results page with postcode search', () => {
         done();
       });
     });
+
     it(`of 'HG5 0JL ' should rank trim the postcode and rank 'Beech House Surgery' in the first ${RESULTS_THRESHOLD} results`, (done) => {
       const search = '';
       const postcode = 'HG5 0JL ';
@@ -84,6 +100,21 @@ describe('Results page with postcode search', () => {
   });
 
   describe('Search by valid outcode', () => {
+    it('of \'HG5\' when search is not there should ignore search param', (done) => {
+      const search = undefined;
+      const postcode = 'HG5';
+
+      makeSearchRequestAndCheckExpectations(search, postcode, (err, res) => {
+        const $ = cheerio.load(res.text);
+        const pageTitle = $('.page-title').text();
+        const resultsHeader = $('.results__header').text();
+
+        expect(pageTitle).to.not.contain('Sorry, we are experiencing technical problems');
+        expect(resultsHeader).to.contain('Which is your surgery?');
+        done();
+      });
+    });
+
     it(`of 'HG5' should rank 'Beech House Surgery' in the first ${RESULTS_THRESHOLD} results`, (done) => {
       const search = '';
       const postcode = 'HG5';

--- a/test/integration/resultsPageErrors.js
+++ b/test/integration/resultsPageErrors.js
@@ -12,51 +12,78 @@ chai.use(chaiHttp);
 
 const resultsRoute = `${constants.SITE_ROOT}/results/`;
 
-function assertSearchResponse(search, assertions) {
+function assertSearchResponse(search, postcode, assertions) {
   chai.request(app)
     .get(resultsRoute)
-    .query({ search })
+    .query({ search, postcode })
     .end(assertions);
 }
 
+function assertEmptyResponse(search, postcode, done) {
+  const errorMessage = messages.emptySearch();
+
+  assertSearchResponse(search, postcode, (err, res) => {
+    const $ = cheerio.load(res.text);
+
+    iExpect.homePageEmptyEntry($);
+    const errorHeader = $('#content').text();
+
+    expect(errorHeader).to.contain(errorMessage);
+    done();
+  });
+}
+
 describe('Results page error handling', () => {
-  describe('when search is not included', () => {
+  describe('when search and postcode are not included', () => {
     it('should return a descriptive error messages', (done) => {
-      const search = null;
-      const errorMessage = messages.emptySearch();
-
-      assertSearchResponse(search, (err, res) => {
-        const $ = cheerio.load(res.text);
-
-        iExpect.homePageEmptyEntry($);
-        const errorHeader = $('#content').text();
-
-        expect(errorHeader).to.contain(errorMessage);
-        done();
-      });
+      const search = undefined;
+      const postcode = undefined;
+      assertEmptyResponse(search, postcode, done);
     });
   });
 
-  describe('when search is an empty string', () => {
+  describe('when search is empty but postcode is not included', () => {
+    it('should return a descriptive error messages', (done) => {
+      const search = '';
+      const postcode = undefined;
+      assertEmptyResponse(search, postcode, done);
+    });
+  });
+
+  describe('when search is not includes but postcode is empty', () => {
+    it('should return a descriptive error messages', (done) => {
+      const search = undefined;
+      const postcode = '';
+      assertEmptyResponse(search, postcode, done);
+    });
+  });
+
+  describe('when search is some empty spaces & postcode is empty', () => {
+    it('should return a descriptive error messages', (done) => {
+      const search = '   ';
+      const postcode = '';
+      assertEmptyResponse(search, postcode, done);
+    });
+  });
+
+  describe('when search is empty & postcode is some empty spaces', () => {
+    it('should return a descriptive error messages', (done) => {
+      const search = '';
+      const postcode = '   ';
+      assertEmptyResponse(search, postcode, done);
+    });
+  });
+
+  describe('when search and postcode are empty strings', () => {
     const search = '';
+    const postcode = '';
 
     it('should return a descriptive error messages', (done) => {
-      const errorMessage = messages.emptySearch();
-
-      assertSearchResponse(search, (err, res) => {
-        iExpect.htmlWith200Status(err, res);
-        const $ = cheerio.load(res.text);
-
-        iExpect.homePageEmptyEntry($);
-        const errorHeader = $('#content').text();
-
-        expect(errorHeader).to.contain(errorMessage);
-        done();
-      });
+      assertEmptyResponse(search, postcode, done);
     });
 
     it('should not contain a back link', (done) => {
-      assertSearchResponse(search, (err, res) => {
+      assertSearchResponse(search, postcode, (err, res) => {
         const $ = cheerio.load(res.text);
 
         expect($('.link-back:first-of-type').length).to.equal(0);
@@ -65,19 +92,28 @@ describe('Results page error handling', () => {
     });
   });
 
-  describe('when search is some empty spaces', () => {
+  describe('when search is not included & postcode is an invalid outcode', () => {
     it('should return a descriptive error messages', (done) => {
-      const search = '   ';
-      const errorMessage = messages.emptySearch();
+      const search = undefined;
+      const postcode = 'S50';
 
-      assertSearchResponse(search, (err, res) => {
-        iExpect.htmlWith200Status(err, res);
+      assertSearchResponse(search, postcode, (err, res) => {
         const $ = cheerio.load(res.text);
 
-        iExpect.homePageEmptyEntry($);
-        const errorHeader = $('#content').text();
+        iExpect.homePageInvalidPostcode($);
+        done();
+      });
+    });
+  });
 
-        expect(errorHeader).to.contain(errorMessage);
+  describe('when search is not included & postcode is an invalid postcode', () => {
+    it('should return a descriptive error messages', (done) => {
+      const search = undefined;
+      const postcode = 'S50 3EW';
+      assertSearchResponse(search, postcode, (err, res) => {
+        const $ = cheerio.load(res.text);
+
+        iExpect.homePageInvalidPostcode($);
         done();
       });
     });

--- a/test/lib/expectations.js
+++ b/test/lib/expectations.js
@@ -13,6 +13,13 @@ function homePageEmptyEntry($) {
   expect($('.form--error .form-item-wrapper > h2').text()).to.contain('You need to enter some text');
 }
 
+function homePageInvalidPostcode($) {
+  homePageBase($);
+  expect($('title').html()).to.match(/^Please retry - Book a GP appointment online/);
+  expect($('.form-item-wrapper').text()).to.contain('The postcode');
+  expect($('.form-item-wrapper').text()).to.contain('does not exist');
+}
+
 function homePage($) {
   homePageBase($);
   expect($('title').html()).to.match(/^Book a GP appointment online/);
@@ -29,5 +36,6 @@ function htmlWith200Status(err, res) {
 module.exports = {
   homePage,
   homePageEmptyEntry,
+  homePageInvalidPostcode,
   htmlWith200Status,
 };


### PR DESCRIPTION
<!--
Thanks for wanting to contribute to this repository.

In order for the changes to be integrated into the repo with as little friction
as possible please follow the guidance here. This includes completing all
sections as fully as possible.
Prior to creating a Pull Request, please ensure there is an open issue for the
changes you wish to make. This will provide visibility to others early in the
process. Potentially other people will wish to help out. It also allows us to
validate the change is inline with our vision for the product.

Provide a general summary of your changes in the Title
-->

## Description
<!--- Describe your changes in detail -->
Making sure that the doctor search/matching is only done when the search is available will result in better flow for the application and no bugs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/nhsuk/gp-finder/issues/204
Relates to https://trello.com/c/xPSoD8G2/461-bug-no-value-for-search-breaks-the-app

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This situation was not handled before, resulting in a 500 error

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] New and updated tests
