### PR TITLE
:raising_hand: Be less specific about third party domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.18.0 / TBD
+===================
+- Be less specific about third party domains within content security policy
+
 0.17.0 / 2017-10-10
 ============
 - Exclude subdomains from Strict-Transport-Security header

--- a/config/express.js
+++ b/config/express.js
@@ -32,55 +32,51 @@ module.exports = (app, config) => {
 
   log.info(nunjucksEnvironment, 'nunjucks environment configuration');
 
-  app.use(helmet.contentSecurityPolicy({
-    directives: {
-      defaultSrc: [
-        '\'self\'',
-      ],
-      childSrc: [
-        'https://*.hotjar.com:*',
-      ],
-      scriptSrc: [
-        '\'self\'',
-        '\'unsafe-inline\'',
-        '\'unsafe-eval\'',
-        'data:',
-        'www.google-analytics.com',
-        's.webtrends.com',
-        'statse.webtrendslive.com',
-        'static.hotjar.com',
-        'script.hotjar.com',
-        'cdn.jsdelivr.net',
-      ],
-      imgSrc: [
-        '\'self\'',
-        'data:',
-        'static.hotjar.com',
-        'www.google-analytics.com',
-        'statse.webtrendslive.com',
-        'hm.webtrends.com',
-      ],
-      styleSrc: [
-        '\'self\'',
-        '\'unsafe-inline\'',
-        'assets.nhs.uk',
-      ],
-      fontSrc: [
-        'assets.nhs.uk',
-      ],
-      connectSrc: [
-        '\'self\'',
-        'https://*.hotjar.com:*',
-        'wss://*.hotjar.com',
-      ],
-    },
+  app.use(helmet({
+    frameguard: { action: 'deny' },
+    hsts: { includeSubDomains: false },
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: [
+          '\'self\'',
+        ],
+        childSrc: [
+          '*.hotjar.com',
+        ],
+        scriptSrc: [
+          '\'self\'',
+          '\'unsafe-eval\'',
+          '\'unsafe-inline\'',
+          'data:',
+          '*.google-analytics.com',
+          '*.hotjar.com',
+          '*.webtrends.com',
+          '*.webtrendslive.com',
+          'cdn.jsdelivr.net',
+        ],
+        imgSrc: [
+          '\'self\'',
+          'data:',
+          '*.google-analytics.com',
+          '*.hotjar.com',
+          '*.webtrends.com',
+          '*.webtrendslive.com',
+        ],
+        styleSrc: [
+          '\'self\'',
+          '\'unsafe-inline\'',
+          'assets.nhs.uk',
+        ],
+        fontSrc: [
+          'assets.nhs.uk',
+        ],
+        connectSrc: [
+          '\'self\'',
+          '*.hotjar.com:*',
+        ],
+      },
+    }
   }));
-  app.use(helmet.xssFilter());
-  app.use(helmet.frameguard({ action: 'deny' }));
-  app.use(helmet.hidePoweredBy());
-  app.use(helmet.ieNoOpen());
-  app.use(helmet.noSniff());
-  app.use(helmet.hsts({ includeSubDomains: false }));
 
   app.use(locals(config));
 

--- a/config/express.js
+++ b/config/express.js
@@ -52,7 +52,6 @@ module.exports = (app, config) => {
           '*.hotjar.com',
           '*.webtrends.com',
           '*.webtrendslive.com',
-          'cdn.jsdelivr.net',
         ],
         imgSrc: [
           '\'self\'',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gp-finder",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Web app to find your GP",
   "main": "server.js",
   "scripts": {

--- a/test/integration/securityHeaders.js
+++ b/test/integration/securityHeaders.js
@@ -12,7 +12,7 @@ describe('app', () => {
       chai.request(app)
         .get('/')
         .end((err, res) => {
-          expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com cdn.jsdelivr.net; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
+          expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
           expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
           expect(res).to.have.header('X-Frame-Options', 'DENY');
           expect(res).to.have.header('X-Content-Type-Options', 'nosniff');

--- a/test/integration/securityHeaders.js
+++ b/test/integration/securityHeaders.js
@@ -12,6 +12,7 @@ describe('app', () => {
       chai.request(app)
         .get('/')
         .end((err, res) => {
+          expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com cdn.jsdelivr.net; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
           expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
           expect(res).to.have.header('X-Frame-Options', 'DENY');
           expect(res).to.have.header('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
Reason for being less specific on the domains is due to occassional
changes by the third parties which causes functionality to stop working
on our site.

Removal of scheme specification as it defaults to how the page has been
accessed.